### PR TITLE
added scheduled job of clean urls

### DIFF
--- a/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
+++ b/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
@@ -2,6 +2,15 @@ package faang.school.urlshortenerservice.repository;
 
 import faang.school.urlshortenerservice.model.Url;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface UrlRepository extends JpaRepository<Url, String> {
+    @Modifying
+    @Query(nativeQuery = true, value = """
+               DELETE FROM url as u WHERE u.created_at < now() - INTERVAL '1 year' returning u.hash
+            """)
+    List<String> removeUrlOlderThanOneYear();
 }

--- a/src/main/java/faang/school/urlshortenerservice/scheduler/CleanerScheduler.java
+++ b/src/main/java/faang/school/urlshortenerservice/scheduler/CleanerScheduler.java
@@ -1,0 +1,32 @@
+package faang.school.urlshortenerservice.scheduler;
+
+import faang.school.urlshortenerservice.mapper.HashMapper;
+import faang.school.urlshortenerservice.repository.HashRepository;
+import faang.school.urlshortenerservice.repository.UrlRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CleanerScheduler {
+    private final UrlRepository urlRepository;
+    private final HashRepository hashRepository;
+    private final HashMapper hashMapper;
+
+    @Scheduled(cron = "${clean-url-cron}")
+    @Transactional
+    void cleanUrl() {
+        log.info("Start job: clean outdated url and populate hash");
+        long startTime = System.currentTimeMillis();
+        List<String> hashes = urlRepository.removeUrlOlderThanOneYear();
+        hashRepository.saveAll(hashMapper.toEntities(hashes));
+        long endTime = System.currentTimeMillis();
+        log.info("Duration of execution: " + (endTime - startTime) / 1000 + " seconds.");
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,3 +31,5 @@ logging:
 numbers:
   uniq:
     number: 50000
+
+clean-url-cron: 0 8 * * * *


### PR DESCRIPTION
Задание
Создать бин CleanerScheduler, который будет запускать джобу для удаления старых ассоциаций в таблице url и сохранять освободившиеся хэши обратно в таблицу hash. Запускается раз в день.

Критерии приема
CleanerScheduler — спринг бин с аннотацией{{@Scheduled}}. Не забыть про @EnableScheduling .

cron лежит в конфиге и получается в @Scheduled через spring expression.

Джоба запускается раз в сутки по крону.

Джоба удаляет из таблицы url все записи старше 1 года с получением их хэшей (можно сделать одновременно в postgres через returning слово)..

Эти хэши переносятся в таблицу hash.

Все происходит в рамках одной транзакции.

Для доступа к данным используются бины UrlRepository и HashRepository.

Везде используются lombok аннотации.