### PR TITLE
BJS2-28108 - Джоб для освобождения неиспользуемых хэшей

### DIFF
--- a/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
+++ b/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
@@ -2,11 +2,20 @@ package faang.school.urlshortenerservice.repository;
 
 import faang.school.urlshortenerservice.model.Url;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UrlRepository extends JpaRepository<Url, String> {
     Optional<Url> findByHash(String hash);
+
+    @Modifying
+    @Query(nativeQuery = true, value = "DELETE FROM url WHERE created_at < :date RETURNING hash")
+    List<String> deleteOldUrlsAndReturnHashes(@Param("date") LocalDateTime date);
 }

--- a/src/main/java/faang/school/urlshortenerservice/scheduler/CleanerScheduler.java
+++ b/src/main/java/faang/school/urlshortenerservice/scheduler/CleanerScheduler.java
@@ -1,0 +1,31 @@
+package faang.school.urlshortenerservice.scheduler;
+
+import faang.school.urlshortenerservice.repository.HashRepository;
+import faang.school.urlshortenerservice.repository.UrlRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CleanerScheduler {
+    private final UrlRepository urlRepository;
+    private final HashRepository hashRepository;
+
+    @Value("${cleanup.expiration-years:1}")
+    private int yearsBeforeExpiration;
+
+    @Transactional
+    @Scheduled(cron = "${cleanup.cron:0 0 0 * * *}")
+    public void cleanOldUrls() {
+        LocalDateTime expirationDate = LocalDateTime.now().minusYears(yearsBeforeExpiration);
+        List<String> hashes = new ArrayList<>(urlRepository.deleteOldUrlsAndReturnHashes(expirationDate));
+        hashRepository.save(hashes);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,12 +38,16 @@ executor:
 
   hash-cache:
     core-size: 10
-    max-size: 15
+    max-size: 20
     queue-capacity: 100
     prefix: HashCache-
 
 hash:
   cache:
+    key: urlMappings
     capacity: 10000
     fill-percentage: 20
-    key: "urlMappings"
+
+cleanup:
+  cron: 0 0 0 * * *
+  expiration-years: 1


### PR DESCRIPTION
- **`CleanerScheduler`**:
  - Scheduled task that runs periodically based on a cron expression.
  - Deletes URLs from the database that are older than a configurable number of years.
  - Retrieves the hashes of the deleted URLs and saves them in the `HashRepository`.

- **`deleteOldUrlsAndReturnHashes`**:
  - Custom repository method that deletes URLs older than the specified date and returns their hashes.