### PR TITLE
Джоб для освобождения неиспользуемых хэшей 42494

### DIFF
--- a/src/main/java/faang/school/urlshortenerservice/repository/UrlCacheRepository.java
+++ b/src/main/java/faang/school/urlshortenerservice/repository/UrlCacheRepository.java
@@ -22,9 +22,4 @@ public class UrlCacheRepository {
     public void save(String hash, String url) {
         redisTemplate.opsForValue().set(hash, url, Duration.ofHours(redisCacheConfigProperties.getTtlTimeHours()));
     }
-
-    public boolean delete(String hash) {
-        Boolean deleted = redisTemplate.delete(hash);
-        return Boolean.TRUE.equals(deleted);
-    }
 }

--- a/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
+++ b/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
@@ -22,7 +22,7 @@ public interface UrlRepository extends JpaRepository<Url, String> {
     Optional<String> findByHash(String hash);
 
     @Modifying
-    @Query("""
+    @Query(nativeQuery = true, value = """
             DELETE FROM Url u
             WHERE u.createdAt < :date
             RETURNING u.hash

--- a/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
+++ b/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
@@ -3,6 +3,7 @@ package faang.school.urlshortenerservice.repository;
 import faang.school.urlshortenerservice.entity.Hash;
 import faang.school.urlshortenerservice.entity.Url;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -20,6 +21,7 @@ public interface UrlRepository extends JpaRepository<Url, String> {
             """)
     Optional<String> findByHash(String hash);
 
+    @Modifying
     @Query("""
             DELETE FROM Url u
             WHERE u.createdAt < :date

--- a/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
+++ b/src/main/java/faang/school/urlshortenerservice/repository/UrlRepository.java
@@ -1,15 +1,29 @@
 package faang.school.urlshortenerservice.repository;
 
+import faang.school.urlshortenerservice.entity.Hash;
 import faang.school.urlshortenerservice.entity.Url;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UrlRepository extends JpaRepository<Url, String> {
 
-    @Query("SELECT u.url FROM Url u WHERE u.hash = :hash")
+    @Query("""
+            SELECT u.url
+            FROM Url u
+            WHERE u.hash = :hash
+            """)
     Optional<String> findByHash(String hash);
+
+    @Query("""
+            DELETE FROM Url u
+            WHERE u.createdAt < :date
+            RETURNING u.hash
+            """)
+    List<Hash> deleteOldUrlsAndReturnHashes(LocalDate date);
 }

--- a/src/main/java/faang/school/urlshortenerservice/service/scheduler/CleanerScheduler.java
+++ b/src/main/java/faang/school/urlshortenerservice/service/scheduler/CleanerScheduler.java
@@ -18,10 +18,10 @@ public class CleanerScheduler {
     private final UrlRepository urlRepository;
     private final HashRepository hashRepository;
 
-    @Value("${server.scheduler.cleaner.days-threshold}")
+    @Value("${server.hash.scheduler.cleaner.days-threshold}")
     private int daysThreshold;
 
-    @Scheduled(cron = "${server.scheduler.cleaner.cron}")
+    @Scheduled(cron = "${server.hash.scheduler.cleaner.cron}")
     @Transactional
     public void clearUnusedUrls() {
         LocalDate oneYearAgo = LocalDate.now().minusDays(daysThreshold);

--- a/src/main/java/faang/school/urlshortenerservice/service/scheduler/CleanerScheduler.java
+++ b/src/main/java/faang/school/urlshortenerservice/service/scheduler/CleanerScheduler.java
@@ -1,0 +1,35 @@
+package faang.school.urlshortenerservice.service.scheduler;
+
+import faang.school.urlshortenerservice.entity.Hash;
+import faang.school.urlshortenerservice.repository.HashRepository;
+import faang.school.urlshortenerservice.repository.UrlRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CleanerScheduler {
+    private final UrlRepository urlRepository;
+    private final HashRepository hashRepository;
+
+    @Value("${server.scheduler.cleaner.days-threshold}")
+    private int daysThreshold;
+
+    @Scheduled(cron = "${server.scheduler.cleaner.cron}")
+    @Transactional
+    public void clearUnusedUrls() {
+        LocalDate oneYearAgo = LocalDate.now().minusDays(daysThreshold);
+
+        List<Hash> hashesToRecycle = urlRepository.deleteOldUrlsAndReturnHashes(oneYearAgo);
+
+        if (!hashesToRecycle.isEmpty()) {
+            hashRepository.saveBatch(hashesToRecycle);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,6 +39,11 @@ server:
       batch:
         size: 10000
 
+    scheduler:
+      cleaner:
+        days-threshold: 365
+        cron: "0 0 0 * * ?"
+
 
   async:
     thread:


### PR DESCRIPTION
Задание

Создать бин CleanerScheduler, который будет запускать джобу для удаления старых ассоциаций в таблице url и сохранять освободившиеся хэши обратно в таблицу hash. Запускается раз в день.

Критерии приема

CleanerScheduler — спринг бин с аннотацией{{@Scheduled}}. Не забыть про @EnableScheduling .

cron лежит в конфиге и получается в @Scheduled через spring expression.

Джоба запускается раз в сутки по крону.

Джоба удаляет из таблицы url все записи старше 1 года с получением их хэшей (можно сделать одновременно в postgres через returning слово)..

Эти хэши переносятся в таблицу hash.

Все происходит в рамках одной транзакции.

Для доступа к данным используются бины UrlRepository и HashRepository.

Везде используются lombok аннотации.

